### PR TITLE
Fixes #5: Derive Shared keys

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,1 @@
+[{"lib/dnscrypt/utils/crypto.ex", :no_return}]

--- a/lib/dnscrypt.ex
+++ b/lib/dnscrypt.ex
@@ -1,18 +1,28 @@
 defmodule Dnscrypt do
   @moduledoc """
-  Documentation for DnscryptEx.
+  Documentation for Dnscrypt.
   """
 
-  @doc """
-  Hello world.
+  alias Dnscrypt.Network
+  alias Dnscrypt.Utils.Crypto
+  alias Dnscrypt.Types.Certificate
 
-  ## Examples
+  # TODO(ian): Determine how this info will be provided
+  @client_sk :crypto.strong_rand_bytes(32)
 
-      iex> Dnscrypt.hello
-      :world
-
-  """
-  def hello do
-    :world
+  @spec query(
+          hostname :: String.t(),
+          resolver_host :: String.t(),
+          resolver_ip :: String.t(),
+          resolver_port :: non_neg_integer()
+        ) :: any()
+  def query(hostname, resolver_host, resolver_ip, resolver_port)
+      when is_bitstring(hostname) and is_bitstring(resolver_ip) and is_bitstring(resolver_host) and
+             is_number(resolver_port) do
+    with {:ok, %Certificate{es_version: algorithm, public_key: resolver_public_key}} <-
+           Network.fetch_dns_certificate(resolver_host, resolver_ip, resolver_port),
+         {:ok, shared_key} <- Crypto.derive_shared_key(algorithm, @client_sk, resolver_public_key) do
+      {:ok, shared_key}
+    end
   end
 end

--- a/lib/dnscrypt/network.ex
+++ b/lib/dnscrypt/network.ex
@@ -10,13 +10,16 @@ defmodule Dnscrypt.Network do
           hostname :: String.t(),
           resolver_ip :: String.t(),
           resolver_port :: number()
-        ) :: binary() | {:error, :failed_to_fetch_resolver_certificate}
+        ) :: {:ok, Certificate.t()} | {:error, :failed_to_fetch_resolver_certificate}
   def fetch_dns_certificate(hostname, resolver_ip, resolver_port) do
     case DNS.query(hostname, :txt, {resolver_ip, resolver_port}) do
       %DNS.Record{anlist: [%DNS.Resource{data: [data]} | _rest]} ->
-        data
-        |> Enum.into(<<>>, fn x -> <<x>> end)
-        |> Certificate.from_binary()
+        cert =
+          data
+          |> Enum.into(<<>>, fn x -> <<x>> end)
+          |> Certificate.from_binary()
+
+        {:ok, cert}
 
       _ ->
         {:error, :failed_to_fetch_resolver_certificate}

--- a/lib/dnscrypt/utils/crypto.ex
+++ b/lib/dnscrypt/utils/crypto.ex
@@ -1,6 +1,7 @@
 defmodule Dnscrypt.Utils.Crypto do
   @moduledoc false
 
+  alias Salty.Box.{Curve25519xchacha20poly1305, Curve25519xsalsa20poly1305}
   alias Dnscrypt.Types.Query
 
   @spec encrypt_query(
@@ -10,23 +11,58 @@ defmodule Dnscrypt.Utils.Crypto do
           client_nonce_pad :: binary(),
           client_query :: binary(),
           client_query_pad :: binary()
-        ) :: {:ok, binary()}
+        ) :: {:ok, binary()} | {:error, :failed_to_encrypt_query}
   def encrypt_query(
-        :xchacha20poly1305,
+        algorithm,
         shared_key,
         client_nonce,
-        client_nonce_pad,
+        # TODO(ian): Are these _pad necessary, or can I just use `create_padding`?
+        _client_nonce_pad,
         client_query,
-        client_query_pad
+        _client_query_pad
       ) do
-    {:ok, <<0>>}
+    padded_nonce = client_nonce <> create_padding(12)
+
+    # TODO(ian): Do whatever is necessary after this case, not complete
+    try do
+      case algorithm do
+        :xchacha20poly1305 ->
+          Curve25519xchacha20poly1305.easy_afternm(client_query, padded_nonce, shared_key)
+
+        :xsalsa20poly1305 ->
+          Curve25519xsalsa20poly1305.easy_afternm(client_query, padded_nonce, shared_key)
+      end
+    rescue
+      _ -> {:error, :failed_to_encrypt_query}
+    end
   end
 
-  @spec derive_shared_key(client_sk :: binary(), resolver_pk :: binary()) ::
-          {:ok, binary()} | {:error, :failed_to_derive_shared_key}
-  def derive_shared_key(client_sk, resolver_pk)
+  @spec derive_shared_key(
+          algorithm :: Query.algorithm(),
+          client_sk :: binary(),
+          resolver_pk :: binary()
+        ) ::
+          {:ok, binary()}
+          | {:error, :failed_to_derive_shared_key}
+          | {:error, :invalid_shared_key_derivation_data}
+  def derive_shared_key(:xchacha20poly1305, client_sk, resolver_pk)
       when is_binary(client_sk) and is_binary(resolver_pk) do
-    {:ok, <<0>>}
+    case Curve25519xchacha20poly1305.beforenm(client_sk, resolver_pk) do
+      {:ok, _derived_key} = response -> response
+      _ -> {:error, :failed_to_derive_shared_key}
+    end
+  end
+
+  def derive_shared_key(:xsalsa20poly1305, client_sk, resolver_pk)
+      when is_binary(client_sk) and is_binary(resolver_pk) do
+    case Curve25519xsalsa20poly1305.beforenm(client_sk, resolver_pk) do
+      {:ok, _derived_key} = response -> response
+      _ -> {:error, :failed_to_derive_shared_key}
+    end
+  end
+
+  def derive_shared_key(_, _, _) do
+    {:error, :invalid_shared_key_derivation_data}
   end
 
   @doc """

--- a/lib/dnscrypt/utils/crypto.ex
+++ b/lib/dnscrypt/utils/crypto.ex
@@ -4,6 +4,8 @@ defmodule Dnscrypt.Utils.Crypto do
   alias Salty.Box.{Curve25519xchacha20poly1305, Curve25519xsalsa20poly1305}
   alias Dnscrypt.Types.Query
 
+  import Dnscrypt.Utils.Guards
+
   @spec encrypt_query(
           algorithm :: Query.algorithm(),
           shared_key :: binary(),
@@ -38,7 +40,7 @@ defmodule Dnscrypt.Utils.Crypto do
   end
 
   @spec derive_shared_key(
-          algorithm :: Query.algorithm(),
+          algorithm :: atom,
           client_sk :: binary(),
           resolver_pk :: binary()
         ) ::
@@ -46,23 +48,19 @@ defmodule Dnscrypt.Utils.Crypto do
           | {:error, :failed_to_derive_shared_key}
           | {:error, :invalid_shared_key_derivation_data}
   def derive_shared_key(:xchacha20poly1305, client_sk, resolver_pk)
-      when is_binary(client_sk) and is_binary(resolver_pk) do
+      when is_binary_of_octet_size(client_sk, 32) and is_binary_of_octet_size(resolver_pk, 32) do
     case Curve25519xchacha20poly1305.beforenm(client_sk, resolver_pk) do
-      {:ok, _derived_key} = response -> response
+      {:ok, _key} = response -> response
       _ -> {:error, :failed_to_derive_shared_key}
     end
   end
 
   def derive_shared_key(:xsalsa20poly1305, client_sk, resolver_pk)
-      when is_binary(client_sk) and is_binary(resolver_pk) do
+      when is_binary_of_octet_size(client_sk, 32) and is_binary_of_octet_size(resolver_pk, 32) do
     case Curve25519xsalsa20poly1305.beforenm(client_sk, resolver_pk) do
-      {:ok, _derived_key} = response -> response
+      {:ok, _key} = response -> response
       _ -> {:error, :failed_to_derive_shared_key}
     end
-  end
-
-  def derive_shared_key(_, _, _) do
-    {:error, :invalid_shared_key_derivation_data}
   end
 
   @doc """

--- a/lib/types/certificate.ex
+++ b/lib/types/certificate.ex
@@ -49,6 +49,7 @@ defmodule Dnscrypt.Types.Certificate do
   @spec new(
           es_version :: Query.algorithm(),
           signature :: binary(),
+          public_key :: binary(),
           client_magic :: binary(),
           serial :: binary(),
           valid_from :: DateTime.t(),
@@ -65,7 +66,8 @@ defmodule Dnscrypt.Types.Certificate do
         valid_until,
         extensions \\ []
       )
-      when is_valid_encryption_algorithm(es_version) do
+      when is_valid_encryption_algorithm(es_version) and
+             is_binary_of_octet_size(public_key, @public_key_bit_len / 8) do
     %__MODULE__{
       es_version: es_version,
       signature: signature,

--- a/test/dnscrypt_ex_test.exs
+++ b/test/dnscrypt_ex_test.exs
@@ -1,8 +1,4 @@
 defmodule DnscryptTest do
   use ExUnit.Case
   doctest Dnscrypt
-
-  test "greets the world" do
-    assert Dnscrypt.hello() == :world
-  end
 end


### PR DESCRIPTION
```
lib/dnscrypt.ex:24:pattern_match
The pattern can never match the type.

Pattern:
{:ok, _shared_key}

Type:
{:error, :invalid_shared_key_derivation_data}
```

Will pick it up again in the morning